### PR TITLE
Add ability to run URL rewrite generation without running full reindex

### DIFF
--- a/Console/Command/RegenerateUrlRewrites.php
+++ b/Console/Command/RegenerateUrlRewrites.php
@@ -20,6 +20,7 @@ class RegenerateUrlRewrites extends Command
 {
     const INPUT_KEY_STOREID = 'storeId';
     const INPUT_KEY_SAVE_REWRITES_HISTORY = 'save-old-urls';
+    const INPUT_KEY_NO_REINDEX = 'no-reindex';
 
     /**
      * @var \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory
@@ -85,7 +86,13 @@ class RegenerateUrlRewrites extends Command
                     null,
                     InputOption::VALUE_NONE,
                     'Save current URL Rewrites'
-                )
+                ),
+                new InputOption(
+                    self::INPUT_KEY_NO_REINDEX,
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Do not run reindex when URL rewrites are generated.'
+                 )
             ]);
     }
 
@@ -99,6 +106,7 @@ class RegenerateUrlRewrites extends Command
     {
         set_time_limit(0);
         $saveOldUrls = false;
+        $runReindex = true;
         $allStores = $this->getAllStoreIds();
         $storesList = [];
         $output->writeln('Regenerating of URL rewrites:');
@@ -109,6 +117,9 @@ class RegenerateUrlRewrites extends Command
             $saveOldUrls = true;
         }
 
+        if (isset($options[self::INPUT_KEY_NO_REINDEX]) && $options[self::INPUT_KEY_NO_REINDEX] === true) {
+            $runReindex = false;
+        }
 
         // get store Id (if was set)
         $storeId = $input->getArgument(self::INPUT_KEY_STOREID);
@@ -188,8 +199,11 @@ class RegenerateUrlRewrites extends Command
 
         $output->writeln('');
         $output->writeln('');
-        $output->writeln('Reindexation...');
-        shell_exec('php bin/magento indexer:reindex');
+
+        if ($runReindex == true) {
+            $output->writeln('Reindexation...');
+            shell_exec('php bin/magento indexer:reindex');
+        }
 
         $output->writeln('Cache refreshing...');
         shell_exec('php bin/magento cache:clean');

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ or
 * to save a current URL rewrites (e.g.: you've updated a name of product(s)/category(-ies) and want to get a new URL rewites and save current):
 >`$> bin/magento ok:urlrewrites:regenerate --save-old-urls`
 
+* to do not run full reindex at the end of Url rewrites generation:
+>`$> bin/magento ok:urlrewrites:regenerate --no-reindex`
+
 * also you can combine a options:
 >`$> bin/magento ok:urlrewrites:regenerate 2 --save-old-urls`
 or


### PR DESCRIPTION
I added an optional parameter which allows disabling full reindex.

In my case I wanted to avoid running full reindex and just run particular indexes. When index:reindex is executed, Aheadworks advanced reports are regenerated what takes really long time.