### PR TITLE
Add --onlyCategories parameter

### DIFF
--- a/Console/Command/RegenerateUrlRewrites.php
+++ b/Console/Command/RegenerateUrlRewrites.php
@@ -85,9 +85,17 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesLayer
             return;
         }
 
+        // get category filter
+        $this->onlyCategories = (bool) $input->getOption(self::INPUT_KEY_ONLY_CATEGORIES);
+        if ($this->onlyCategories) {
+            $this->_dataUrlRewriteClassNames = [
+                DataCategoryUrlRewriteDatabaseMap::class
+            ];
+        }
+
         // remove all current url rewrites
         if (count($storesList) > 0 && !$this->_saveOldUrls) {
-            $this->removeAllUrlRewrites($storesList, $productsFilter);
+            $this->removeAllUrlRewrites($storesList, $productsFilter, $this->onlyCategories ? 'category' : null);
         }
 
         // set area code if needed
@@ -146,7 +154,9 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesLayer
                 }
                 $category->setData('url_path', null)->setData('url_key', null)->setStoreId($storeId)->save();
 
-                $this->resetCategoryProductsUrlKeyPath($category, $storeId);
+                if (!$this->onlyCategories) {
+                    $this->resetCategoryProductsUrlKeyPath($category, $storeId);
+                }
             } catch (\Exception $e) {
                 // debugging
                 $this->_displayExceptionMsg('Exception #1: '. $e->getMessage() .' Category ID: '. $category->getId());

--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ or
 * to save a current URL rewrites (e.g.: you've updated a name of product(s)/category(-ies) and want to get a new URL rewites and save current):
 >`$> bin/magento ok:urlrewrites:regenerate --save-old-urls`
 
+* to regenerate URL rewrites only for categories
+>`$> bin/magento ok:urlrewrites:regenerate --onlyCategories`
+
 * to do not run full reindex at the end of Url rewrites generation:
 >`$> bin/magento ok:urlrewrites:regenerate --no-reindex`
 
 * also you can combine a options:
 >`$> bin/magento ok:urlrewrites:regenerate 2 --save-old-urls`
 or
->`$> bin/magento ok:urlrewrites:regenerate --storeId=2 --save-old-urls`
+>`$> bin/magento ok:urlrewrites:regenerate --storeId=2 --save-old-urls --onlyCategories`
 
 ## HOW TO USE DEBUG INFORMATION:
 If you see in the console log a message(-s) like this:


### PR DESCRIPTION
The new  `onlyCategories` option allows to restrict URL rewrite generation to only categories. By default, both are regenerated. An `entityFilter` option as originally intended is not feasible because for product URL rewrites, category URL rewrites are needed

Solves #42 