### PR TITLE
Add --no-cache-clean and --no-cache-flush options

### DIFF
--- a/Console/Command/RegenerateUrlRewrites.php
+++ b/Console/Command/RegenerateUrlRewrites.php
@@ -54,6 +54,14 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesLayer
             $this->_runReindex = false;
         }
 
+        if (isset($options[self::INPUT_KEY_NO_CACHE_CLEAN]) && $options[self::INPUT_KEY_NO_CACHE_CLEAN] === true) {
+            $this->_runCacheClean = false;
+        }
+
+        if (isset($options[self::INPUT_KEY_NO_CACHE_FLUSH]) && $options[self::INPUT_KEY_NO_CACHE_FLUSH] === true) {
+            $this->_runCacheFlush = false;
+        }
+
         if (isset($options[self::INPUT_KEY_PRODUCTS_RANGE])) {
             $productsFilter = $this->generateProductsIdsRange($options[self::INPUT_KEY_PRODUCTS_RANGE]);
         }
@@ -112,15 +120,20 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesLayer
         $this->_output->writeln('');
         $this->_output->writeln('');
 
-        if ($this->_runReindex == true) {
+        if ($this->_runReindex) {
             $this->_output->writeln('Reindexation...');
             shell_exec('php bin/magento indexer:reindex');
         }
-
-        $this->_output->writeln('Cache refreshing...');
-        shell_exec('php bin/magento cache:clean');
-        shell_exec('php bin/magento cache:flush');
-        $this->_output->writeln('If you use some external cache mechanisms (e.g.: Redis, Varnish, etc.) - please, refresh this external cache.');
+        if ($this->_runCacheClean || $this->_runCacheFlush) {
+            $this->_output->writeln('Cache refreshing...');
+            if ($this->_runCacheClean) {
+                shell_exec('php bin/magento cache:clean');
+            }
+            if ($this->_runCacheFlush) {
+                shell_exec('php bin/magento cache:flush');
+            }
+            $this->_output->writeln('If you use some external cache mechanisms (e.g.: Redis, Varnish, etc.) - please, refresh this external cache.');
+        }
         $this->_output->writeln('Finished');
     }
 

--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -36,6 +36,8 @@ abstract class RegenerateUrlRewritesAbstract extends Command
     const INPUT_KEY_STOREID = 'storeId';
     const INPUT_KEY_SAVE_REWRITES_HISTORY = 'save-old-urls';
     const INPUT_KEY_NO_REINDEX = 'no-reindex';
+    const INPUT_KEY_NO_CACHE_FLUSH = 'no-cache-flush';
+    const INPUT_KEY_NO_CACHE_CLEAN = 'no-cache-clean';
     const INPUT_KEY_PRODUCTS_RANGE = 'products-range';
 
     /**
@@ -134,6 +136,16 @@ abstract class RegenerateUrlRewritesAbstract extends Command
     protected $_runReindex = true;
 
     /**
+     * @var boolean
+     */
+    protected $_runCacheClean = true;
+
+    /**
+     * @var boolean
+     */
+    protected $_runCacheFlush = true;
+
+    /**
      * @var integer
      */
     protected $_step = 0;
@@ -216,6 +228,18 @@ abstract class RegenerateUrlRewritesAbstract extends Command
                     null,
                     InputOption::VALUE_NONE,
                     'Do not run reindex when URL rewrites are generated.'
+                ),
+                new InputOption(
+                    self::INPUT_KEY_NO_CACHE_FLUSH,
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Do not run cache:flush when URL rewrites are generated.'
+                ),
+                new InputOption(
+                    self::INPUT_KEY_NO_CACHE_CLEAN,
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Do not run cache:clean when URL rewrites are generated.'
                 ),
                 new InputOption(
                     self::INPUT_KEY_PRODUCTS_RANGE,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ or
 * to do not run full reindex at the end of Url rewrites generation:
 >`$> bin/magento ok:urlrewrites:regenerate --no-reindex`
 
+* to do not run cache:clean at the end of Url rewrites generation:
+>`$> bin/magento ok:urlrewrites:regenerate --no-cache-clean`
+
+* to do not run cache:flush at the end of Url rewrites generation:
+>`$> bin/magento ok:urlrewrites:regenerate --no-cache-flush`
+
 * also you can combine a options:
 >`$> bin/magento ok:urlrewrites:regenerate 2 --save-old-urls`
 or


### PR DESCRIPTION
To maintain backwards compatibility, I added two options and both commands are still executed by default

Altthough, my recommendation would be to only use `cache:clean` by default

Solves #45 