### PR TITLE
Add --no-progress option to disable dot output

### DIFF
--- a/Console/Command/RegenerateUrlRewrites.php
+++ b/Console/Command/RegenerateUrlRewrites.php
@@ -54,6 +54,10 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesLayer
             $this->_runReindex = false;
         }
 
+        if (isset($options[self::INPUT_KEY_NO_PROGRESS]) && $options[self::INPUT_KEY_NO_PROGRESS] === true) {
+            $this->_showProgress = false;
+        }
+
         if (isset($options[self::INPUT_KEY_PRODUCTS_RANGE])) {
             $productsFilter = $this->generateProductsIdsRange($options[self::INPUT_KEY_PRODUCTS_RANGE]);
         }

--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -36,6 +36,7 @@ abstract class RegenerateUrlRewritesAbstract extends Command
     const INPUT_KEY_STOREID = 'storeId';
     const INPUT_KEY_SAVE_REWRITES_HISTORY = 'save-old-urls';
     const INPUT_KEY_NO_REINDEX = 'no-reindex';
+    const INPUT_KEY_NO_PROGRESS = 'no-progress';
     const INPUT_KEY_PRODUCTS_RANGE = 'products-range';
 
     /**
@@ -134,6 +135,11 @@ abstract class RegenerateUrlRewritesAbstract extends Command
     protected $_runReindex = true;
 
     /**
+     * @var boolean
+     */
+    protected $_showProgress = true;
+
+    /**
      * @var integer
      */
     protected $_step = 0;
@@ -216,6 +222,12 @@ abstract class RegenerateUrlRewritesAbstract extends Command
                     null,
                     InputOption::VALUE_NONE,
                     'Do not run reindex when URL rewrites are generated.'
+                ),
+                new InputOption(
+                    self::INPUT_KEY_NO_PROGRESS,
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Do not show progress indicator.'
                 ),
                 new InputOption(
                     self::INPUT_KEY_PRODUCTS_RANGE,
@@ -426,6 +438,9 @@ abstract class RegenerateUrlRewritesAbstract extends Command
      */
     protected function _displayProgressDots()
     {
+        if (!$this->_showProgress) {
+            return;
+        }
         $this->_step++;
         $this->_output->write('.');
         // max 70 dots in log line


### PR DESCRIPTION
This is useful in automated build environments.