### PR TITLE
Don't use save on categories

### DIFF
--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -30,6 +30,7 @@ use Magento\CatalogUrlRewrite\Model\Map\DataCategoryUrlRewriteDatabaseMap;
 use Magento\CatalogUrlRewrite\Model\Map\DataProductUrlRewriteDatabaseMap;
 use Magento\Catalog\Model\ResourceModel\Product\ActionFactory as ProductActionFactory;
 use Magento\Framework\App\State as AppState;
+use Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator;
 
 abstract class RegenerateUrlRewritesAbstract extends Command
 {
@@ -132,6 +133,11 @@ abstract class RegenerateUrlRewritesAbstract extends Command
     protected $_appState;
 
     /**
+     * @var Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator
+     */
+    protected $_categoryUrlPathGenerator;
+
+    /**
      * @var integer
      */
     protected $_step = 0;
@@ -178,7 +184,8 @@ abstract class RegenerateUrlRewritesAbstract extends Command
         UrlRewriteHandlerFactory\Proxy $urlRewriteHandlerFactory,
         DatabaseMapPool\Proxy $databaseMapPool,
         ProductActionFactory\Proxy $productActionFactory,
-        AppState\Proxy $appState
+        AppState\Proxy $appState,
+        CategoryUrlPathGenerator $categoryUrlPathGenerator
     ) {
         $this->_resource = $resource;
         $this->_categoryCollectionFactory = $categoryCollectionFactory;
@@ -196,6 +203,7 @@ abstract class RegenerateUrlRewritesAbstract extends Command
             DataProductUrlRewriteDatabaseMap::class
         ];
         $this->_appState = $appState;
+        $this->_categoryUrlPathGenerator = $categoryUrlPathGenerator;
         parent::__construct();
     }
 
@@ -626,7 +634,9 @@ abstract class RegenerateUrlRewritesAbstract extends Command
             if ($this->_commandOptions['saveOldUrls']) {
                 $category->setData('save_rewrites_history', true);
             }
-            $category->setData('url_path', null)->setData('url_key', null)->setStoreId($storeId)->save();
+            $category->setStoreId($storeId);
+            $category->setUrlPath($this->_categoryUrlPathGenerator->getUrlPath($category));
+            $category->getResource()->saveAttribute($category, 'url_path');
 
             $this->_resetCategoryProductsUrlKeyPath($category, $storeId);
 


### PR DESCRIPTION
Using `save` on categories for regenerating the url paths has a side effect: all attribute values which exist on the global scope of categories are saved to the store view level. This creates duplicate entries in the database, plus if you change the global values, it has no effect as the store view scope values overrule the global values.
This PR changes that behavior and just uses the function to generate the url path directly.