### PR TITLE
Use proxy in command

### DIFF
--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -185,7 +185,7 @@ abstract class RegenerateUrlRewritesAbstract extends Command
         DatabaseMapPool\Proxy $databaseMapPool,
         ProductActionFactory\Proxy $productActionFactory,
         AppState\Proxy $appState,
-        CategoryUrlPathGenerator $categoryUrlPathGenerator
+        CategoryUrlPathGenerator\Proxy $categoryUrlPathGenerator
     ) {
         $this->_resource = $resource;
         $this->_categoryCollectionFactory = $categoryCollectionFactory;


### PR DESCRIPTION
This is a bugfix for PR #51. When installing a fresh database (e.g. for integration tests) the setup would fail with:

```
Installing database schema:

  [Zend_Db_Statement_Exception]

  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento.flag' doesn't exist, query was: SELECT `flag`.* FROM `flag` WHERE (`flag`.`flag_code`='staging')
```

Because the commands are instantiated early and `CategoryUrlPathGenerator` has a dependency to `Magento\Framework\Locale\Resolver`, a class with logic in the constructor