### PR TITLE
Change the url_key regeneration behavior to use UrlPathGenerators instead

### DIFF
--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -23,6 +23,7 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductColl
 use Magento\Catalog\Model\ResourceModel\Product\ActionFactory as ProductActionFactory;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGeneratorFactory;
+use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGeneratorFactory;
 use Magento\CatalogUrlRewrite\Model\UrlRewriteBunchReplacer;
 use Magento\CatalogUrlRewrite\Model\Map\DatabaseMapPool;
@@ -84,6 +85,11 @@ abstract class RegenerateUrlRewritesAbstract extends Command
      * @var Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator
      */
     protected $_categoryUrlPathGenerator;
+
+    /**
+     * @var Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator
+     */
+    protected $_productUrlPathGenerator;
 
     /**
      * @var \Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGeneratorFactory
@@ -189,6 +195,7 @@ abstract class RegenerateUrlRewritesAbstract extends Command
         ProductActionFactory\Proxy $productActionFactory,
         CategoryUrlPathGenerator\Proxy $categoryUrlPathGenerator,
         CategoryUrlRewriteGeneratorFactory\Proxy $categoryUrlRewriteGeneratorFactory,
+        ProductUrlPathGenerator\Proxy $productUrlPathGenerator,
         ProductUrlRewriteGeneratorFactory\Proxy $productUrlRewriteGeneratorFactory,
         UrlRewriteBunchReplacer\Proxy $urlRewriteBunchReplacer,
         UrlRewriteHandlerFactory\Proxy $urlRewriteHandlerFactory,
@@ -203,6 +210,7 @@ abstract class RegenerateUrlRewritesAbstract extends Command
         $this->_productActionFactory = $productActionFactory;
         $this->_categoryUrlPathGenerator = $categoryUrlPathGenerator;
         $this->_categoryUrlRewriteGeneratorFactory = $categoryUrlRewriteGeneratorFactory;
+        $this->_productUrlPathGenerator = $productUrlPathGenerator;
         $this->_productUrlRewriteGeneratorFactory = $productUrlRewriteGeneratorFactory;
         $this->_urlRewriteBunchReplacer = $urlRewriteBunchReplacer;
         $this->_urlRewriteHandlerFactory = $urlRewriteHandlerFactory;

--- a/Console/Command/RegenerateUrlRewritesCategoryAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesCategoryAbstract.php
@@ -74,7 +74,7 @@ abstract class RegenerateUrlRewritesCategoryAbstract extends RegenerateUrlRewrit
             $category->setStoreId($storeId);
             $category->setUrlPath($this->_categoryUrlPathGenerator->getUrlPath($category));
             $category->getResource()->saveAttribute($category, 'url_path');
-            $category->setUrlKey($category->formatUrlKey($category->getName()));
+            $category->setUrlKey($this->_categoryUrlPathGenerator->getUrlKey($category));
             $category->getResource()->saveAttribute($category, 'url_key');
 
             $this->_regenerateCategoryUrlRewrites($category, $storeId);

--- a/Console/Command/RegenerateUrlRewritesProductAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesProductAbstract.php
@@ -71,12 +71,17 @@ abstract class RegenerateUrlRewritesProductAbstract extends RegenerateUrlRewrite
             if ($this->_commandOptions['saveOldUrls']) {
                 $product->setData('save_rewrites_history', true);
             }
+
+            $generatedKey = $this->_productUrlPathGenerator->getUrlKey($product);
+
             $this->_getProductAction()->updateAttributes(
                 [$product->getId()],
-                ['url_path' => null, 'url_key' => $product->formatUrlKey($product->getName())],
+                ['url_path' => null, 'url_key' => $generatedKey],
                 $storeId
             );
-            $product->setData('url_path', null)->setData('url_key', $product->formatUrlKey($product->getName()))->setStoreId($storeId);
+            $product->setData('url_path', null)
+                    ->setData('url_key', $generatedKey)
+                    ->setStoreId($storeId);
             $productUrlRewriteResult = $this->_getProductUrlRewriteGenerator()->generate($product);
 
             $productUrlRewriteResult = $this->_sanitizeProductUrlRewrites($productUrlRewriteResult);


### PR DESCRIPTION
In order to allow the use of different url_key generation behavior, the use of the ProductUrlPathGenerator and CategoryUrlPathGenerator allow the correct regeneration of url_key and url_path. 

Please see https://github.com/werfu/magento2-url-key-mask as to why you should use this behavior instead.