### PR TITLE
Fix generating URL Rewrites with slash as URL suffix

### DIFF
--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -529,6 +529,6 @@ abstract class RegenerateUrlRewritesAbstract extends Command
      */
     protected function _clearRequestPath($requestPath)
     {
-        return trim($requestPath, '/');
+        return ltrim($requestPath, '/');
     }
 }


### PR DESCRIPTION
Right now in admin  >> Stores >> Configuration >> Catalog >> Catalog for "Product URL Suffix" could be selected "/". In this case all products should have slash at the end of URL. But this module generates URL rewrites without slack at the end.

This PR fixes issue.