### PR TITLE
 Generate URL Rewrites only for assigned product stores

### DIFF
--- a/Console/Command/RegenerateUrlRewritesAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesAbstract.php
@@ -423,7 +423,7 @@ abstract class RegenerateUrlRewritesAbstract extends Command
             return;
         }
 
-        $perc = (double)($this->_progress / $this->_total);
+        $perc = $this->_total ? (double)($this->_progress / $this->_total) : 1;
         $bar = floor($perc * $size);
 
         $status_bar = "\r[";

--- a/Console/Command/RegenerateUrlRewritesProductAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesProductAbstract.php
@@ -132,6 +132,7 @@ abstract class RegenerateUrlRewritesProductAbstract extends RegenerateUrlRewrite
         $productsCollection = $this->_productCollectionFactory->create();
 
         $productsCollection->setStore($storeId)
+            ->addStoreFilter($storeId)
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('visibility')
             ->addAttributeToSelect('url_key')


### PR DESCRIPTION
Right now URL rewrites generated for all store views, even when product is not assigned to that store.

This PR prevents generating URL Rewrites for stores that not related to product.

Also as we might have 0 total results - added check that total is not zero. I think it should also fix #84