### PR TITLE
Fix url key generation after #77

### DIFF
--- a/Console/Command/RegenerateUrlRewritesProductAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesProductAbstract.php
@@ -72,16 +72,20 @@ abstract class RegenerateUrlRewritesProductAbstract extends RegenerateUrlRewrite
                 $product->setData('save_rewrites_history', true);
             }
 
+            $product->setData('url_path', null)
+                ->setData('url_key', null)
+                ->setStoreId($storeId);
+
             $generatedKey = $this->_productUrlPathGenerator->getUrlKey($product);
+
+            $product->setData('url_key', $generatedKey);
 
             $this->_getProductAction()->updateAttributes(
                 [$product->getId()],
                 ['url_path' => null, 'url_key' => $generatedKey],
                 $storeId
             );
-            $product->setData('url_path', null)
-                    ->setData('url_key', $generatedKey)
-                    ->setStoreId($storeId);
+            
             $productUrlRewriteResult = $this->_getProductUrlRewriteGenerator()->generate($product);
 
             $productUrlRewriteResult = $this->_sanitizeProductUrlRewrites($productUrlRewriteResult);


### PR DESCRIPTION
In #77 was changed behavior, now url key is NOT re-generated, as url key already set.

In Magento we have following code - if URL key is null - then re-generate it:
https://github.com/magento/magento2/blob/06e9ad872482fddfb471a091f625e7389905742d/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php#L117-L139

This PR sets url_key to null to trigger url key re-generation