### PR TITLE
[Bugfix] Generate lowest level first

### DIFF
--- a/Console/Command/RegenerateUrlRewritesCategoryAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesCategoryAbstract.php
@@ -155,7 +155,7 @@ abstract class RegenerateUrlRewritesCategoryAbstract extends RegenerateUrlRewrit
             ->addAttributeToSelect('url_key')
             ->addAttributeToSelect('url_path')
             ->addFieldToFilter('level', array('gt' => '1'))
-            ->setOrder('level', 'DESC')
+            ->setOrder('level', 'ASC')
             // use limit to avoid a "eating" of a memory
             ->setPageSize($this->_categoriesCollectionPageSize);
 


### PR DESCRIPTION
Using Magento 2.2.7 which patches:
* [MAGETWO-95539](https://github.com/magento/magento2/commit/6e20e2e642bdb8a5fee6b5a0979591ff0b4f71e1.patch)
* [MAGETWO-95818](https://github.com/magento/magento2/commit/daffedf8638585ac230aacd2c1cea18c437a3810.patch)

We have some conflicted (disabled) categories in a subtree, e.g:

```
Default Category
 ├ Category 1
    ├ Subcategory 1
    ├ Subcategory 2 (conflict with 3)
    ├ Subcategory 3 (conflict with 2)
```
Generating only _Subcategory 1_, generation works. Generating all or also only _Category 1_ and _Subcategory 1_  remove all rewrites for the whole subtree, cause of `\Magento\UrlRewrite\Model\Storage\DbStorage::doReplace` (`deleteOldUrls`)

By change sort order of the category collection to **level ASC** will skip the subcategory-Conflict and leave generated rewrite for _Subcategory 1_