### PR TITLE
Set orig-data for url_key to null, to trigger url_path regeneration

### DIFF
--- a/Console/Command/RegenerateUrlRewritesCategoryAbstract.php
+++ b/Console/Command/RegenerateUrlRewritesCategoryAbstract.php
@@ -73,7 +73,8 @@ abstract class RegenerateUrlRewritesCategoryAbstract extends RegenerateUrlRewrit
             }
             $category->setStoreId($storeId);
 
-            if (!$this->_commandOptions['noRegenUrlKey']) {
+            if (!$this->_commandOptions['noRegenUrlKey']) {// force regeneration
+                $category->setOrigData('url_key', null);
                 $category->setUrlKey($this->_categoryUrlPathGenerator->getUrlKey($category));
                 $category->getResource()->saveAttribute($category, 'url_key');
             }


### PR DESCRIPTION
I'm not really sure, why `url_key` and `url_path` is running out of synced locally, but cause if I run this script for all stores-id and without `--no-regen-url-key` saves only `url_path`.

To clear this difference, it is not possible to avoid the `regen`-flag, because `\Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator::getUrlPath` checks `dataHasChangedFor`.
Remove orig-data in object force a regeneration.

Magento 2.2.7