### PR TITLE
Adapt to Magento 2.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Add into Magento 2 a CLI feature which allow to regenerate a Url Rewrites of products and categories",
     "keywords": ["magento", "magento2 extension", "magento 2 extension", "extension", "module", "magento2 module", "magento 2 module"],
     "type": "magento2-module",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "homepage": "https://github.com/olegkoval/magento2-regenerate_url_rewrites",
     "authors": [
         {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -10,7 +10,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\Framework\Console\CommandList">
+    <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="ok:urlrewrites:regenerate" xsi:type="object">OlegKoval\RegenerateUrlRewrites\Console\Command\RegenerateUrlRewrites</item>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="OlegKoval_RegenerateUrlRewrites" setup_version="1.5.6">
+    <module name="OlegKoval_RegenerateUrlRewrites" setup_version="1.6.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Catalog"/>


### PR DESCRIPTION
As of Magento 2.3.5 console commands mus be added to `Magento\Framework\Console\CommandListInterface` instead of a concrete class in order to be available in command list.
In order to reflect this, I also incremented the minor release version, though Magento suggests to reflect this kind of things via `requires` in `composer.json` (which I didn't add in order to keep the patch small).