### PR TITLE
Force re-generate url_path for category

### DIFF
--- a/Model/RegenerateCategoryRewrites.php
+++ b/Model/RegenerateCategoryRewrites.php
@@ -213,7 +213,8 @@ class RegenerateCategoryRewrites extends AbstractRegenerateRewrites
             $category->setUrlKey($this->_getCategoryUrlPathGenerator()->getUrlKey($category->setUrlKey(null)));
             $category->getResource()->saveAttribute($category, 'url_key');
         }
-
+        
+        $category->unsUrlPath();
         $category->setUrlPath($this->_getCategoryUrlPathGenerator()->getUrlPath($category));
         $category->getResource()->saveAttribute($category, 'url_path');
 


### PR DESCRIPTION
Right now, when we have incorrect url_path saved in DB for the category - from this incorrect value all URLs are getting generated.


Right now it's just re-using old value
https://github.com/magento/magento2/blob/7c6b6365a3c099509d6f6e6c306cb1821910aab0/app/code/Magento/CatalogUrlRewrite/Model/CategoryUrlPathGenerator.php#L76-L79

My PR removes old value of url_path, and then generates a new value, similar to what Magento does 
 https://github.com/magento/magento2/blame/7c6b6365a3c099509d6f6e6c306cb1821910aab0/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Category/Move.php#L71-L72