### PR TITLE
fixed unstable key ordering in rewrite row data

### DIFF
--- a/Model/AbstractRegenerateRewrites.php
+++ b/Model/AbstractRegenerateRewrites.php
@@ -349,6 +349,10 @@ abstract class AbstractRegenerateRewrites
             $result[] = $rewrite;
         }
 
+        array_walk($result, function (&$rowData) {
+            ksort($rowData);
+        });
+
         return $result;
     }
 


### PR DESCRIPTION
Inside \OlegKoval\RegenerateUrlRewrites\Model\AbstractRegenerateRewrites::_prepareUrlRewrites code `$rewrite = $urlRewrite->toArray();` can return array with different key orders for different urlrewrite type (in my case it was 0 & 301), in parent function result go to insertOnDuplicate & it make not correct db update.
So after loop end make key order in all row data the same