### PR TITLE
Execute method must be of type int in Magento 2.4.6

### DIFF
--- a/Console/Command/RegenerateUrlRewrites.php
+++ b/Console/Command/RegenerateUrlRewrites.php
@@ -115,7 +115,7 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesAbstract
      * Regenerate Url Rewrites
      * @param  InputInterface  $input
      * @param  OutputInterface $output
-     * @return void
+     * @return int 0 if everything went fine, or an exit code
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -166,6 +166,8 @@ class RegenerateUrlRewrites extends RegenerateUrlRewritesAbstract
 
         $this->_showSupportMe();
         $this->_output->writeln('Finished');
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Magento 2.4.6, PHP 8.2
After end process of bin/magento ok:urlrewrites:regenerate

There is an error in /.../vendor/symfony/console/Command/Command.php at line: 301
Return value of "OlegKoval\RegenerateUrlRewrites\Console\Command\RegenerateUrlRewrites::execute()" must be of the type int, "null" returned.#0

https://github.com/olegkoval/magento2-regenerate_url_rewrites/issues/165

as per: vendor/symfony/console/Command/Command.php
protected function execute @return int 0 if everything went fine, or an exit code

so to fix this error we just need to add return 0; at the end of execute() function in vendor/olegkoval/magento2-regenerate-url-rewrites/Console/Command/RegenerateUrlRewrites.php