### PR TITLE
Exclude non visible products from url regeneration

### DIFF
--- a/Model/RegenerateProductRewrites.php
+++ b/Model/RegenerateProductRewrites.php
@@ -265,6 +265,7 @@ class RegenerateProductRewrites extends AbstractRegenerateRewrites
             ->addAttributeToSelect('visibility')
             ->addAttributeToSelect('url_key')
             ->addAttributeToSelect('url_path')
+            ->addAttributeToFilter('visibility', ['neq' => 1])
             // use limit to avoid a "eating" of a memory
             ->setPageSize($this->productsCollectionPageSize);
 

--- a/Model/RegenerateProductRewrites.php
+++ b/Model/RegenerateProductRewrites.php
@@ -10,6 +10,7 @@
 
 namespace OlegKoval\RegenerateUrlRewrites\Model;
 
+use Magento\Catalog\Model\Product\Visibility;
 use OlegKoval\RegenerateUrlRewrites\Helper\Regenerate as RegenerateHelper;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Catalog\Model\ResourceModel\Product\ActionFactory as ProductActionFactory;
@@ -265,7 +266,7 @@ class RegenerateProductRewrites extends AbstractRegenerateRewrites
             ->addAttributeToSelect('visibility')
             ->addAttributeToSelect('url_key')
             ->addAttributeToSelect('url_path')
-            ->addAttributeToFilter('visibility', ['neq' => 1])
+            ->addAttributeToFilter('visibility', ['neq' => Visibility::VISIBILITY_NOT_VISIBLE])
             // use limit to avoid a "eating" of a memory
             ->setPageSize($this->productsCollectionPageSize);
 


### PR DESCRIPTION
As already mentioned in a previous issue (https://github.com/olegkoval/magento2-regenerate_url_rewrites/issues/12#issuecomment-382732750), products that are not visible individually ignored when regenerating URLs.

One solution is to filter the product collection by visibility (like seen here: https://github.com/olegkoval/magento2-regenerate_url_rewrites/issues/130#issuecomment-635256375)

In one of my cases, this brought down the time needed to process all products from ~14 minutes to ~5 minutes.